### PR TITLE
Allow setting props to Shadow wrapping View

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { I18nManager, PixelRatio, Platform, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
+import type { ViewProps } from 'react-native';
 import { Defs, LinearGradient, Mask, Path, RadialGradient, Rect, Stop, Svg } from 'react-native-svg';
 import { parseToRgb, rgbToColorString } from 'polished'; // To extract alpha
 import type { RgbaColor } from 'polished/lib/types/color';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -143,6 +143,8 @@ export interface ShadowProps {
    *
    * @default false */
   safeRender?: boolean;
+  /** View props for shadow wrapping view */
+  shadowViewProps?: Omit<ViewProps, 'style'>;
 }
 
 
@@ -162,6 +164,7 @@ export const Shadow: React.FC<ShadowProps> = ({
   paintInside: paintInsideProp,
   viewStyle,
   safeRender = false,
+  shadowViewProps = {},
 }) => {
   const isRTL = I18nManager.isRTL;
 
@@ -434,7 +437,7 @@ export const Shadow: React.FC<ShadowProps> = ({
     return (
       // pointerEvents: https://github.com/SrBrahma/react-native-shadow-2/issues/24
       <View style={[containerViewStyle]} pointerEvents='box-none'>
-        <View style={{ width: '100%', height: '100%', position: 'absolute', left: offsetX, top: offsetY }}>
+        <View {...shadowViewProps} style={{ width: '100%', height: '100%', position: 'absolute', left: offsetX, top: offsetY }}>
           {shadow}
         </View>
         <View


### PR DESCRIPTION
Hi,

I'm missing the functionality of setting custom properties to the shadow wrapper View, in my case I am looking to set `pointerEvents` to `none` to avoid shadow handling touch gestures that should be handled by the view underneath the shadow.