### PR TITLE
Fix X offset not applied on IOS

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -492,7 +492,13 @@ function getResult({
     // pointerEvents: https://github.com/SrBrahma/react-native-shadow-2/issues/24
     <View style={containerStyle} pointerEvents='box-none' {...containerViewProps}>
       <View pointerEvents='none' {...shadowViewProps} style={[
-        StyleSheet.absoluteFillObject,
+         {
+          position: "absolute",
+          start: 0,
+          end: 0,
+          top: 0,
+          bottom: 0,
+          },,
         shadowViewProps?.style,
         { start: offset[0], top: offset[1] },
       ]}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -498,7 +498,7 @@ function getResult({
           end: 0,
           top: 0,
           bottom: 0,
-          },,
+          },
         shadowViewProps?.style,
         { start: offset[0], top: offset[1] },
       ]}


### PR DESCRIPTION
Fix to match usage of 'start' instead of 'left', which apparently caused issue with application of offset on IOS (https://github.com/SrBrahma/react-native-shadow-2/issues/67)