### PR TITLE
fix: pixel gap from top and bottom in rtl mode

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -513,7 +513,7 @@ function getShadow({
               style={{
                 position: 'absolute',
                 top: -distance,
-                start: topStart,
+                start: topStart+ (isRTL ? 1 : 0),
                 ...(isRTL && rtlScaleX),
               }}
             >
@@ -537,7 +537,7 @@ function getShadow({
               style={{
                 position: 'absolute',
                 top: height,
-                start: bottomStart,
+                start: bottomStart+ (isRTL ? 1 : 0),
                 ...(isRTL && rtlScaleX),
               }}
             >


### PR DESCRIPTION
fixed: https://github.com/SrBrahma/react-native-shadow-2/issues/28
reference https://github.com/SrBrahma/react-native-shadow-2/pull/61

https://snack.expo.dev/ssSCzEhwY here is a reproducible example for IOS RTL mode. this issue is fixed by my PR